### PR TITLE
Add monitoring for original context in `extendedConnection` struct

### DIFF
--- a/extendtimeout/connection.go
+++ b/extendtimeout/connection.go
@@ -21,22 +21,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/edwarnicke/log"
 	"go.fd.io/govpp/api"
 )
 
 type extendedConnection struct {
 	api.Connection
 	contextTimeout time.Duration
-}
-
-type extendedContext struct {
-	context.Context
-	valuesContext context.Context
-}
-
-func (ec *extendedContext) Value(key interface{}) interface{} {
-	return ec.valuesContext.Value(key)
 }
 
 // NewConnection - creates a wrapper for vpp connection that uses extended context timeout for all operations
@@ -48,50 +38,26 @@ func NewConnection(vppConn api.Connection, contextTimeout time.Duration) api.Con
 }
 
 func (c *extendedConnection) Invoke(ctx context.Context, req, reply api.Message) error {
-	ctx, cancel := c.withExtendedTimeoutCtx(ctx)
+	ctx, cancel := c.withExtendedTimeoutContext(ctx)
 	err := c.Connection.Invoke(ctx, req, reply)
 	cancel()
 	return err
 }
 
-func (c *extendedConnection) cancelMonitorCtx(ctx context.Context) (cancelMonitorCtx context.Context, cancel func()) {
-	cancelCtx, cancelFunc := context.WithCancel(context.Background())
-	cancelCh := make(chan struct{})
+func (c *extendedConnection) withExtendedTimeoutContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	var cancelContext, cancel = context.WithCancel(context.Background())
+	var timeoutContext, timeoutCancel = context.WithTimeout(cancelContext, c.contextTimeout)
 	go func() {
+		<-timeoutContext.Done()
+		timeoutCancel()
 		select {
-		case <-time.After(c.contextTimeout):
-			<-ctx.Done()
-		case <-cancelCh:
+		case <-cancelContext.Done():
+			return
+		case <-ctx.Done():
+			cancel()
+			return
 		}
-		cancelFunc()
 	}()
 
-	cancelMonitorCtx = &extendedContext{
-		Context:       cancelCtx,
-		valuesContext: ctx,
-	}
-	cancel = func() {
-		cancelCh <- struct{}{}
-		close(cancelCh)
-	}
-	return
-}
-
-func (c *extendedConnection) withExtendedTimeoutCtx(ctx context.Context) (extendedCtx context.Context, cancel func()) {
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		return c.cancelMonitorCtx(ctx)
-	}
-
-	minDeadline := time.Now().Add(c.contextTimeout)
-	if minDeadline.Before(deadline) {
-		return c.cancelMonitorCtx(ctx)
-	}
-	log.Entry(ctx).Warnf("Context deadline has been extended by extendtimeout from %v to %v", deadline, minDeadline)
-	deadline = minDeadline
-	postponedCtx, cancel := context.WithDeadline(context.Background(), deadline)
-	return &extendedContext{
-		Context:       postponedCtx,
-		valuesContext: ctx,
-	}, cancel
+	return cancelContext, cancel
 }


### PR DESCRIPTION
## Description
Add monitoring of original context canceling in `extendedConnection`

## Issue
https://github.com/networkservicemesh/cmd-forwarder-vpp/issues/1133